### PR TITLE
quickfix for ntuple row creation & a G4 include name

### DIFF
--- a/qCal-Source/src/qCalEventAction.cc
+++ b/qCal-Source/src/qCalEventAction.cc
@@ -102,7 +102,7 @@ void qCalEventAction::EndOfEventAction(const G4Event* anEvent)
    
    //Get the Analysis Manager
    auto analysisManager = G4AnalysisManager::Instance();
-   analysisManager->SetNtupleMerging(true);
+   //analysisManager->SetNtupleMerging(true);
    analysisManager->SetVerboseLevel(1);
    // Filling Histograms and ntuples
    for (G4int i = 0; i < SDVolume; ++i){

--- a/qCal-Source/src/qCalRunMessenger.cc
+++ b/qCal-Source/src/qCalRunMessenger.cc
@@ -1,7 +1,7 @@
 #include "qCalRunMessenger.hh"
 #include "qCalRunAction.hh"
 #include "G4UIdirectory.hh"
-#include "G4UICommand.hh"
+#include "G4UIcommand.hh"
 #include "G4RunManager.hh"
 
 #include "G4UIcmdWithAString.hh"


### PR DESCRIPTION
The "set ntuple merging" method of analysis manager prevents new ntuple rows from being added if it occurs again in eventAction.cc. That line is removed. The gui command header file in runMessenger.c was misspelled w.r.t. the latest version of G4 and is now corrected. 